### PR TITLE
only run publish.ts on repository dispatch

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,8 +1,9 @@
 name: Publish on NPM
 on:
-  schedule:
-    - cron: "0 10 * * *"
   push:
+    branches: [main]
+  repository_dispatch:
+    types: [publish]
 env:
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/publish.ts
+++ b/publish.ts
@@ -24,7 +24,7 @@ const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
   ).data.tag_name.replace("v", "");
   const currentVersion = (
     await octokit.request("GET /repos/{owner}/{repo}/releases/latest", {
-      owner: "maltejur",
+      owner: "devicons",
       repo: "react-devicons",
     })
   ).data.tag_name.replace("v", "");
@@ -47,14 +47,14 @@ const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
     console.log(" - Creating github release");
     const release_id = (
       await octokit.request("POST /repos/{owner}/{repo}/releases", {
-        owner: "maltejur",
+        owner: "devicons",
         repo: "react-devicons",
         tag_name: `v${deviconVersion}`,
       })
     ).data.id;
     await exec("zip react-devicons.zip dist -r");
     await axios({
-      url: `https://uploads.github.com/repos/maltejur/react-devicons/releases/${release_id}/assets?name=react-devicons.zip`,
+      url: `https://uploads.github.com/repos/devicons/react-devicons/releases/${release_id}/assets?name=react-devicons.zip`,
       data: Buffer.from(await fsAsync.readFile("./react-devicons.zip")),
       headers: {
         Authorization: `token ${process.env.GITHUB_TOKEN}`,


### PR DESCRIPTION
The goal is to have the main repository sent a repository dispatch via the GitHub API when a new release is created signaling this repo to create a new release. I will create a PR there in the near future.

Closes #3 #2 

See https://github.com/devicons/devicon/pull/848